### PR TITLE
[+] universal router swap with offchain permit

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ All the best on your journey. - Maka
 |                                 |  [ eth_send_private.py           ]( flashbots/eth_send_private.py            ) | Using Flashbots endpoint to send a private transaction.      | 
 |                                 |  [ mev_send_bundle.py            ]( flashbots/mev_send_bundle.py             ) | Building and sending a classic bundle.                       |     
 | > [ general    ]( general    )  |                                                                                | **Overrides, bloom filters, log topics and wider EVM**       |
-|                                 |  [ bloom_filter.py               ]( general/bloom_filter.py                  ) | filtering the `logsBloom` for more efficient searches.       |
+|                                 |  [ bloom_filter.py               ]( general/bloom_filter.py                  ) | Filtering the `logsBloom` for more efficient searches.       |
 |                                 |  [ multi2.py                     ]( general/multi2.py                        ) | Using a popular mulicall contract, to batch static requests. |
 |                                 |  [ swap_topic.py                 ]( general/swap_topic.py                    ) | How to encode and pull a `Event` topic.                      |
 |                                 |  [ transfer_override.py          ]( general/transfer_override.py             ) | Overiding an accounts ERC20 balance, prior to an `eth_call`. |
@@ -45,6 +45,7 @@ All the best on your journey. - Maka
 | > [ signing    ]( signing/   )  |                                                                                | **Offchain signing, permits, EIP712**                        |
 |                                 |  [ pysign.py                     ]( signing/pysign.py                        ) | Deprectated signing pattern.                                 |
 |                                 |  [ setMasterContractApproval.py  ]( signing/setMasterContractApproval.py     ) | Building and signing an EIP712 digest.                       |
+|                                 |  [ universal_permit2_extended.py ]( signing/universal_permit2_extended.py    ) | Building an offchain permit for Universal router (long way). |
 | > [ sushiswap  ]( sushiswap/ )  |                                                                                | **Sushi specific**                                           |
 |                                 |  [ exact_input.py                ]( sushiswap/exact_input.py                 ) | Trident single hop swap.                                     |
 |                                 |  [ get_kava_farms.py             ]( sushiswap/get_kava_farms.py              ) | Get a list of all farms from a chef.                         |
@@ -71,7 +72,7 @@ All the best on your journey. - Maka
 | > [ uni_router ]( uni_router/)  |                                                                                | **Uniswaps Universal router**                                |
 |                                 |  [ universal_router_swap.md      ]( uni_router/universal_router_swap.md      ) | Notes on Uniswaps Universal Router.                          |
 |                                 |  [ universal_router_swap.py      ]( uni_router/universal_router_swap.py      ) | Wrap and swap from Eth using Universal router..              |
-|                                 |  [ universal_swap_from_token.py  ]( uni_router/universal_swap_from_token.py  ) | Swap from token using Universal router (needs permit).       |
+|                                 |  [ universal_swap_from_token.py  ]( uni_router/universal_swap_from_token.py  ) | Swap from token using Universal router (uses dual tx permit).|
 | > [ zk         ]( zk/        )  |                                                                                | **Anything ZK specific**                                     |
 |                                 |  [ check_balance.py              ]( zk/check_balance.py                      ) | Simple balance check, using the sdk.                         |
 |                                 |  [ transfer.py                   ]( zk/transfer.py                           ) | Simple eth transfer, using the sdk.                          |

--- a/signing/universal_permit2_extended.py
+++ b/signing/universal_permit2_extended.py
@@ -1,0 +1,188 @@
+#---------------------------------------------------------------------------------------------------------------------------------------------------------#
+# UNISWAP UNIVERSAL ROUTER V3 SWAP WITH OFFCHAIN PERMIT2 SIGNATURE - EXTENDED VERSION (WITHOUT ABSTRACTION)
+#---------------------------------------------------------------------------------------------------------------------------------------------------------#
+
+#---------------------------------------------------------------------------------------------------------------------------------------------------------#
+# --- FOREWORD ---
+#---------------------------------------------------------------------------------------------------------------------------------------------------------#
+# Any type of hash verification/recreation can be a tedious excercise when a single difference will drastically change the result, potentially sending you 
+# on a wild goose chase. When hashing hashes of inputs, just double check everything.
+
+from web3 import Web3; w3 = Web3(Web3.HTTPProvider('https://polygon-rpc.com'))
+from os import getenv
+from dotenv import load_dotenv
+load_dotenv()
+eoa = w3.eth.account.from_key(getenv('TKEY'))                                # replace with your own set up
+
+#---------------------------------------------------------------------------------------------------------------------------------------------------------#
+# --- CONSTANTS AND CONFIGS --- - 
+#---------------------------------------------------------------------------------------------------------------------------------------------------------#
+PERMIT_ADDRESS  = '0x000000000022D473030F116dDEE9F6B43aC78BA3'
+USDC_ADDRESS    = '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359'
+WETH_ADDRESS    = '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619'
+ROUTER_ADDRESS  = '0xec7BE89e9d109e7e3Fec59c222CF297125FEFda2'               # always double check the addresses 
+
+ROUTER_ABI = '''
+[{"inputs":[{"components":[{"internalType":"address","name":"permit2","type":"address"},{"internalType":"address","name":"weth9","type":"address"},{"internalType":"address","name":"seaportV1_5","type":"address"},{"internalType":"address","name":"seaportV1_4","type":"address"},{"internalType":"address","name":"openseaConduit","type":"address"},{"internalType":"address","name":"nftxZap","type":"address"},{"internalType":"address","name":"x2y2","type":"address"},{"internalType":"address","name":"foundation","type":"address"},{"internalType":"address","name":"sudoswap","type":"address"},{"internalType":"address","name":"elementMarket","type":"address"},{"internalType":"address","name":"nft20Zap","type":"address"},{"internalType":"address","name":"cryptopunks","type":"address"},{"internalType":"address","name":"looksRareV2","type":"address"},{"internalType":"address","name":"routerRewardsDistributor","type":"address"},{"internalType":"address","name":"looksRareRewardsDistributor","type":"address"},{"internalType":"address","name":"looksRareToken","type":"address"},{"internalType":"address","name":"v2Factory","type":"address"},{"internalType":"address","name":"v3Factory","type":"address"},{"internalType":"bytes32","name":"pairInitCodeHash","type":"bytes32"},{"internalType":"bytes32","name":"poolInitCodeHash","type":"bytes32"}],"internalType":"struct RouterParameters","name":"params","type":"tuple"}],"stateMutability":"nonpayable","type":"constructor"},{"inputs":[],"name":"BalanceTooLow","type":"error"},{"inputs":[],"name":"BuyPunkFailed","type":"error"},{"inputs":[],"name":"ContractLocked","type":"error"},{"inputs":[],"name":"ETHNotAccepted","type":"error"},{"inputs":[{"internalType":"uint256","name":"commandIndex","type":"uint256"},{"internalType":"bytes","name":"message","type":"bytes"}],"name":"ExecutionFailed","type":"error"},{"inputs":[],"name":"FromAddressIsNotOwner","type":"error"},{"inputs":[],"name":"InsufficientETH","type":"error"},{"inputs":[],"name":"InsufficientToken","type":"error"},{"inputs":[],"name":"InvalidBips","type":"error"},{"inputs":[{"internalType":"uint256","name":"commandType","type":"uint256"}],"name":"InvalidCommandType","type":"error"},{"inputs":[],"name":"InvalidOwnerERC1155","type":"error"},{"inputs":[],"name":"InvalidOwnerERC721","type":"error"},{"inputs":[],"name":"InvalidPath","type":"error"},{"inputs":[],"name":"InvalidReserves","type":"error"},{"inputs":[],"name":"InvalidSpender","type":"error"},{"inputs":[],"name":"LengthMismatch","type":"error"},{"inputs":[],"name":"SliceOutOfBounds","type":"error"},{"inputs":[],"name":"TransactionDeadlinePassed","type":"error"},{"inputs":[],"name":"UnableToClaim","type":"error"},{"inputs":[],"name":"UnsafeCast","type":"error"},{"inputs":[],"name":"V2InvalidPath","type":"error"},{"inputs":[],"name":"V2TooLittleReceived","type":"error"},{"inputs":[],"name":"V2TooMuchRequested","type":"error"},{"inputs":[],"name":"V3InvalidAmountOut","type":"error"},{"inputs":[],"name":"V3InvalidCaller","type":"error"},{"inputs":[],"name":"V3InvalidSwap","type":"error"},{"inputs":[],"name":"V3TooLittleReceived","type":"error"},{"inputs":[],"name":"V3TooMuchRequested","type":"error"},{"anonymous":false,"inputs":[{"indexed":false,"internalType":"uint256","name":"amount","type":"uint256"}],"name":"RewardsSent","type":"event"},{"inputs":[{"internalType":"bytes","name":"looksRareClaim","type":"bytes"}],"name":"collectRewards","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"bytes","name":"commands","type":"bytes"},{"internalType":"bytes[]","name":"inputs","type":"bytes[]"}],"name":"execute","outputs":[],"stateMutability":"payable","type":"function"},{"inputs":[{"internalType":"bytes","name":"commands","type":"bytes"},{"internalType":"bytes[]","name":"inputs","type":"bytes[]"},{"internalType":"uint256","name":"deadline","type":"uint256"}],"name":"execute","outputs":[],"stateMutability":"payable","type":"function"},{"inputs":[{"internalType":"address","name":"","type":"address"},{"internalType":"address","name":"","type":"address"},{"internalType":"uint256[]","name":"","type":"uint256[]"},{"internalType":"uint256[]","name":"","type":"uint256[]"},{"internalType":"bytes","name":"","type":"bytes"}],"name":"onERC1155BatchReceived","outputs":[{"internalType":"bytes4","name":"","type":"bytes4"}],"stateMutability":"pure","type":"function"},{"inputs":[{"internalType":"address","name":"","type":"address"},{"internalType":"address","name":"","type":"address"},{"internalType":"uint256","name":"","type":"uint256"},{"internalType":"uint256","name":"","type":"uint256"},{"internalType":"bytes","name":"","type":"bytes"}],"name":"onERC1155Received","outputs":[{"internalType":"bytes4","name":"","type":"bytes4"}],"stateMutability":"pure","type":"function"},{"inputs":[{"internalType":"address","name":"","type":"address"},{"internalType":"address","name":"","type":"address"},{"internalType":"uint256","name":"","type":"uint256"},{"internalType":"bytes","name":"","type":"bytes"}],"name":"onERC721Received","outputs":[{"internalType":"bytes4","name":"","type":"bytes4"}],"stateMutability":"pure","type":"function"},{"inputs":[{"internalType":"bytes4","name":"interfaceId","type":"bytes4"}],"name":"supportsInterface","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"pure","type":"function"},{"inputs":[{"internalType":"int256","name":"amount0Delta","type":"int256"},{"internalType":"int256","name":"amount1Delta","type":"int256"},{"internalType":"bytes","name":"data","type":"bytes"}],"name":"uniswapV3SwapCallback","outputs":[],"stateMutability":"nonpayable","type":"function"},{"stateMutability":"payable","type":"receive"}]
+'''
+PERMIT_ABI = '''
+[{"inputs":[{"internalType":"uint256","name":"deadline","type":"uint256"}],"name":"AllowanceExpired","type":"error"},{"inputs":[],"name":"ExcessiveInvalidation","type":"error"},{"inputs":[{"internalType":"uint256","name":"amount","type":"uint256"}],"name":"InsufficientAllowance","type":"error"},{"inputs":[{"internalType":"uint256","name":"maxAmount","type":"uint256"}],"name":"InvalidAmount","type":"error"},{"inputs":[],"name":"InvalidContractSignature","type":"error"},{"inputs":[],"name":"InvalidNonce","type":"error"},{"inputs":[],"name":"InvalidSignature","type":"error"},{"inputs":[],"name":"InvalidSignatureLength","type":"error"},{"inputs":[],"name":"InvalidSigner","type":"error"},{"inputs":[],"name":"LengthMismatch","type":"error"},{"inputs":[{"internalType":"uint256","name":"signatureDeadline","type":"uint256"}],"name":"SignatureExpired","type":"error"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"owner","type":"address"},{"indexed":true,"internalType":"address","name":"token","type":"address"},{"indexed":true,"internalType":"address","name":"spender","type":"address"},{"indexed":false,"internalType":"uint160","name":"amount","type":"uint160"},{"indexed":false,"internalType":"uint48","name":"expiration","type":"uint48"}],"name":"Approval","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"owner","type":"address"},{"indexed":false,"internalType":"address","name":"token","type":"address"},{"indexed":false,"internalType":"address","name":"spender","type":"address"}],"name":"Lockdown","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"owner","type":"address"},{"indexed":true,"internalType":"address","name":"token","type":"address"},{"indexed":true,"internalType":"address","name":"spender","type":"address"},{"indexed":false,"internalType":"uint48","name":"newNonce","type":"uint48"},{"indexed":false,"internalType":"uint48","name":"oldNonce","type":"uint48"}],"name":"NonceInvalidation","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"owner","type":"address"},{"indexed":true,"internalType":"address","name":"token","type":"address"},{"indexed":true,"internalType":"address","name":"spender","type":"address"},{"indexed":false,"internalType":"uint160","name":"amount","type":"uint160"},{"indexed":false,"internalType":"uint48","name":"expiration","type":"uint48"},{"indexed":false,"internalType":"uint48","name":"nonce","type":"uint48"}],"name":"Permit","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"owner","type":"address"},{"indexed":false,"internalType":"uint256","name":"word","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"mask","type":"uint256"}],"name":"UnorderedNonceInvalidation","type":"event"},{"inputs":[],"name":"DOMAIN_SEPARATOR","outputs":[{"internalType":"bytes32","name":"","type":"bytes32"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"","type":"address"},{"internalType":"address","name":"","type":"address"},{"internalType":"address","name":"","type":"address"}],"name":"allowance","outputs":[{"internalType":"uint160","name":"amount","type":"uint160"},{"internalType":"uint48","name":"expiration","type":"uint48"},{"internalType":"uint48","name":"nonce","type":"uint48"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"token","type":"address"},{"internalType":"address","name":"spender","type":"address"},{"internalType":"uint160","name":"amount","type":"uint160"},{"internalType":"uint48","name":"expiration","type":"uint48"}],"name":"approve","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"token","type":"address"},{"internalType":"address","name":"spender","type":"address"},{"internalType":"uint48","name":"newNonce","type":"uint48"}],"name":"invalidateNonces","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint256","name":"wordPos","type":"uint256"},{"internalType":"uint256","name":"mask","type":"uint256"}],"name":"invalidateUnorderedNonces","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"components":[{"internalType":"address","name":"token","type":"address"},{"internalType":"address","name":"spender","type":"address"}],"internalType":"struct IAllowanceTransfer.TokenSpenderPair[]","name":"approvals","type":"tuple[]"}],"name":"lockdown","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"","type":"address"},{"internalType":"uint256","name":"","type":"uint256"}],"name":"nonceBitmap","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"owner","type":"address"},{"components":[{"components":[{"internalType":"address","name":"token","type":"address"},{"internalType":"uint160","name":"amount","type":"uint160"},{"internalType":"uint48","name":"expiration","type":"uint48"},{"internalType":"uint48","name":"nonce","type":"uint48"}],"internalType":"struct IAllowanceTransfer.PermitDetails[]","name":"details","type":"tuple[]"},{"internalType":"address","name":"spender","type":"address"},{"internalType":"uint256","name":"sigDeadline","type":"uint256"}],"internalType":"struct IAllowanceTransfer.PermitBatch","name":"permitBatch","type":"tuple"},{"internalType":"bytes","name":"signature","type":"bytes"}],"name":"permit","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"owner","type":"address"},{"components":[{"components":[{"internalType":"address","name":"token","type":"address"},{"internalType":"uint160","name":"amount","type":"uint160"},{"internalType":"uint48","name":"expiration","type":"uint48"},{"internalType":"uint48","name":"nonce","type":"uint48"}],"internalType":"struct IAllowanceTransfer.PermitDetails","name":"details","type":"tuple"},{"internalType":"address","name":"spender","type":"address"},{"internalType":"uint256","name":"sigDeadline","type":"uint256"}],"internalType":"struct IAllowanceTransfer.PermitSingle","name":"permitSingle","type":"tuple"},{"internalType":"bytes","name":"signature","type":"bytes"}],"name":"permit","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"components":[{"components":[{"internalType":"address","name":"token","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"internalType":"struct ISignatureTransfer.TokenPermissions","name":"permitted","type":"tuple"},{"internalType":"uint256","name":"nonce","type":"uint256"},{"internalType":"uint256","name":"deadline","type":"uint256"}],"internalType":"struct ISignatureTransfer.PermitTransferFrom","name":"permit","type":"tuple"},{"components":[{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"requestedAmount","type":"uint256"}],"internalType":"struct ISignatureTransfer.SignatureTransferDetails","name":"transferDetails","type":"tuple"},{"internalType":"address","name":"owner","type":"address"},{"internalType":"bytes","name":"signature","type":"bytes"}],"name":"permitTransferFrom","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"components":[{"components":[{"internalType":"address","name":"token","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"internalType":"struct ISignatureTransfer.TokenPermissions[]","name":"permitted","type":"tuple[]"},{"internalType":"uint256","name":"nonce","type":"uint256"},{"internalType":"uint256","name":"deadline","type":"uint256"}],"internalType":"struct ISignatureTransfer.PermitBatchTransferFrom","name":"permit","type":"tuple"},{"components":[{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"requestedAmount","type":"uint256"}],"internalType":"struct ISignatureTransfer.SignatureTransferDetails[]","name":"transferDetails","type":"tuple[]"},{"internalType":"address","name":"owner","type":"address"},{"internalType":"bytes","name":"signature","type":"bytes"}],"name":"permitTransferFrom","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"components":[{"components":[{"internalType":"address","name":"token","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"internalType":"struct ISignatureTransfer.TokenPermissions","name":"permitted","type":"tuple"},{"internalType":"uint256","name":"nonce","type":"uint256"},{"internalType":"uint256","name":"deadline","type":"uint256"}],"internalType":"struct ISignatureTransfer.PermitTransferFrom","name":"permit","type":"tuple"},{"components":[{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"requestedAmount","type":"uint256"}],"internalType":"struct ISignatureTransfer.SignatureTransferDetails","name":"transferDetails","type":"tuple"},{"internalType":"address","name":"owner","type":"address"},{"internalType":"bytes32","name":"witness","type":"bytes32"},{"internalType":"string","name":"witnessTypeString","type":"string"},{"internalType":"bytes","name":"signature","type":"bytes"}],"name":"permitWitnessTransferFrom","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"components":[{"components":[{"internalType":"address","name":"token","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"internalType":"struct ISignatureTransfer.TokenPermissions[]","name":"permitted","type":"tuple[]"},{"internalType":"uint256","name":"nonce","type":"uint256"},{"internalType":"uint256","name":"deadline","type":"uint256"}],"internalType":"struct ISignatureTransfer.PermitBatchTransferFrom","name":"permit","type":"tuple"},{"components":[{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"requestedAmount","type":"uint256"}],"internalType":"struct ISignatureTransfer.SignatureTransferDetails[]","name":"transferDetails","type":"tuple[]"},{"internalType":"address","name":"owner","type":"address"},{"internalType":"bytes32","name":"witness","type":"bytes32"},{"internalType":"string","name":"witnessTypeString","type":"string"},{"internalType":"bytes","name":"signature","type":"bytes"}],"name":"permitWitnessTransferFrom","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"components":[{"internalType":"address","name":"from","type":"address"},{"internalType":"address","name":"to","type":"address"},{"internalType":"uint160","name":"amount","type":"uint160"},{"internalType":"address","name":"token","type":"address"}],"internalType":"struct IAllowanceTransfer.AllowanceTransferDetails[]","name":"transferDetails","type":"tuple[]"}],"name":"transferFrom","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"from","type":"address"},{"internalType":"address","name":"to","type":"address"},{"internalType":"uint160","name":"amount","type":"uint160"},{"internalType":"address","name":"token","type":"address"}],"name":"transferFrom","outputs":[],"stateMutability":"nonpayable","type":"function"}]
+'''
+ERC20_ABI  = '''
+[{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"src","type":"address"},{"indexed":true,"internalType":"address","name":"guy","type":"address"},{"indexed":false,"internalType":"uint256","name":"wad","type":"uint256"}],"name":"Approval","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"dst","type":"address"},{"indexed":false,"internalType":"uint256","name":"wad","type":"uint256"}],"name":"Deposit","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"src","type":"address"},{"indexed":true,"internalType":"address","name":"dst","type":"address"},{"indexed":false,"internalType":"uint256","name":"wad","type":"uint256"}],"name":"Transfer","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"src","type":"address"},{"indexed":false,"internalType":"uint256","name":"wad","type":"uint256"}],"name":"Withdrawal","type":"event"},{"payable":true,"stateMutability":"payable","type":"fallback"},{"constant":true,"inputs":[{"internalType":"address","name":"","type":"address"},{"internalType":"address","name":"","type":"address"}],"name":"allowance","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"internalType":"address","name":"guy","type":"address"},{"internalType":"uint256","name":"wad","type":"uint256"}],"name":"approve","outputs":[{"internalType":"bool","name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[{"internalType":"address","name":"","type":"address"}],"name":"balanceOf","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"decimals","outputs":[{"internalType":"uint8","name":"","type":"uint8"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[],"name":"deposit","outputs":[],"payable":true,"stateMutability":"payable","type":"function"},{"constant":true,"inputs":[],"name":"name","outputs":[{"internalType":"string","name":"","type":"string"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"symbol","outputs":[{"internalType":"string","name":"","type":"string"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"totalSupply","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"internalType":"address","name":"dst","type":"address"},{"internalType":"uint256","name":"wad","type":"uint256"}],"name":"transfer","outputs":[{"internalType":"bool","name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[{"internalType":"address","name":"src","type":"address"},{"internalType":"address","name":"dst","type":"address"},{"internalType":"uint256","name":"wad","type":"uint256"}],"name":"transferFrom","outputs":[{"internalType":"bool","name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[{"internalType":"uint256","name":"wad","type":"uint256"}],"name":"withdraw","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}]
+'''
+
+router    = w3.eth.contract(address=ROUTER_ADDRESS, abi=ROUTER_ABI)
+permit    = w3.eth.contract(address=PERMIT_ADDRESS, abi=PERMIT_ABI)
+token_in  = w3.eth.contract(address=USDC_ADDRESS,  abi=ERC20_ABI )
+token_out = w3.eth.contract(address=WETH_ADDRESS,  abi=ERC20_ABI )
+
+#---------------------------------------------------------------------------------------------------------------------------------------------------------#
+# --- EXAMPLE ---
+#---------------------------------------------------------------------------------------------------------------------------------------------------------#
+# In this scenario we want to swap on Uniswap Universal Router and we want to send our permit with the swap as opposed to approving the router in a prior
+# transaction. Note we still have to approve the permit contract in its own tx as we aren't using a custom contract and all calls will be from an EOA.
+
+# We will swap from a single usdc and only permit the router to spend up to that amount
+swap_amount      = 1 * 10 ** 6
+
+# Will use a deadline far in the future
+expiration       = 2 * 10 ** 10
+
+# We can get a nonce by calling the permit contract and passing owner, token, spender
+nonce            = permit.functions.allowance(eoa.address, token_in.address, router.address).call()[2]
+
+from eth_abi import encode
+from eth_abi.packed import encode_packed
+
+#  @notice The permit data for a token
+#  struct PermitDetails {
+#    // ERC20 token address
+#    address token;
+#    // the maximum amount allowed to spend
+#    uint160 amount;
+#    // timestamp at which a spender's token allowances become invalid
+#    uint48 expiration;
+#    // an incrementing value indexed per owner,token,and spender for each signature
+#    uint48 nonce;
+#  }
+
+#  @notice The permit message signed for a single token allownce
+#  struct PermitSingle {
+#    // the permit data for a single token alownce
+#    PermitDetails details;
+#    // address permissioned on the allowed tokens
+#    address spender;
+#    // deadline on the permit signature
+#    uint256 sigDeadline;
+#  }
+
+from eth_utils import keccak 
+
+# The following texts where pulled from the permit contract, where batch and other hash signatures can be found
+
+PERMIT_DETAILS_TYPEHASH = keccak(text='PermitDetails(address token,uint160 amount,uint48 expiration,uint48 nonce)')
+permit_hash = keccak(encode(
+  ['bytes32','address','uint160','uint48','uint48' ],[ PERMIT_DETAILS_TYPEHASH, token_in.address, swap_amount, expiration, nonce]
+))
+
+PERMIT_SINGLE_TYPEHASH = keccak(
+  text='PermitSingle(PermitDetails details,address spender,uint256 sigDeadline)PermitDetails(address token,uint160 amount,uint48 expiration,uint48 nonce)'
+)
+data_hash = keccak(encode([ 'bytes32','bytes32','address','uint256'],[ PERMIT_SINGLE_TYPEHASH, permit_hash, router.address, expiration ] ))
+
+
+#---------------------------------------------------------------------------------------------------------------------------------------------------------#
+
+# Domain seperators are sometimes cached as a public contract constant but we'll go over how to compute it
+NAME_HASH    = keccak(text='Permit2')    
+TYPE_HASH    = keccak(text='EIP712Domain(string name,uint256 chainId,address verifyingContract)')
+CHAIN_ID     = w3.eth.chain_id
+VERIFYING    = permit.address
+
+DOMAIN_SEPARATOR = keccak(encode(
+  [ 'bytes32','bytes32','uint256','address'],[ TYPE_HASH, NAME_HASH, CHAIN_ID, VERIFYING ]
+))
+
+assert(DOMAIN_SEPARATOR == permit.functions.DOMAIN_SEPARATOR().call())
+
+# generate hash of local data
+hashed_permit = keccak(encode_packed(['string','bytes32','bytes32'],['\x19\x01', DOMAIN_SEPARATOR, data_hash]))
+print(hashed_permit.hex())
+
+# sign the hash
+# signed_hash was deprecated in favour of signed message which can't accidently sign a transaction
+signed_hash   = eoa.unsafe_sign_hash(hashed_permit) # for this raw example and as we have generated the hash it's safe to do
+
+#---------------------------------------------------------------------------------------------------------------------------------------------------------#
+# --- MAIN --- 
+#---------------------------------------------------------------------------------------------------------------------------------------------------------#
+def main():
+
+  # Will skip details on command byte mechanics as a more in depth step through can be found in the dedicated 
+  # universal_router.md in the uni_router folder. 
+  # To summarise we will pass the permit, then use it to transfer the tokens and swap.
+  PERMIT2_PERMIT        = '0a'
+  V3_SWAP_EXACT_IN      = '00'
+  commands              = '0x' + PERMIT2_PERMIT + V3_SWAP_EXACT_IN 
+
+  permit2_permit        = encode(
+    [ '(address,uint160,uint48,uint48)','address','uint256', 'bytes'],
+    [ (token_in.address, swap_amount, expiration, nonce), router.address, expiration, signed_hash.signature ]
+  )
+
+  to          = eoa.address
+  slippage    = 0     # use something close to desired amount
+  fee         = 500   # effects the pool that address that will be calculated, check this for your case.
+  path        = encode_packed(['address','uint24','address'], [token_in.address, fee, token_out.address])
+
+  from_eoa    = True
+  v3_calldata = encode(['address', 'uint256', 'uint256', 'bytes', 'bool'], [to, swap_amount, slippage, path, from_eoa])
+
+  execute     = router.functions.execute(commands, [ permit2_permit, v3_calldata ], expiration)
+  
+  # --
+
+  # can max this to only ever do it once for all protocols that support the contract on that chain
+  approval    = token_in.functions.approve(permit.address, swap_amount) 
+
+  # --
+
+  tx = { 
+         'from' : eoa.address, 'value'       : 0,                    'chainId'             : w3.eth.chain_id, 
+         'gas'  : 250000,      'maxFeePerGas': w3.eth.gas_price * 2, 'maxPriorityFeePerGas': w3.eth.max_priority_fee*2, 
+         'nonce': w3.eth.get_transaction_count(eoa.address)
+ 
+       }
+
+  # We can't do this approval in the same transaction when from EOA.
+  approve     = approval.build_transaction(tx)
+  print ('[-] Approving permit... ')
+  tx_hash     = send_tx(sign_tx(approve, eoa.key))
+  receipt     = w3.eth.wait_for_transaction_receipt(tx_hash)
+  print (f'[+] Approved PERMIT2 at TOKEN contract: {tx_hash}\n[>] {receipt}')
+
+  tx.update({'nonce': w3.eth.get_transaction_count(eoa.address)})
+
+  # Now we can swap using the permit.
+  swap        = execute.build_transaction(tx)
+  print(swap)
+  print('[-] Simulating swap...')
+  w3.eth.call(swap)
+  print('[-] Attempting swap...')
+  tx_hash     = send_tx(sign_tx(swap, eoa.key))
+  receipt     = w3.eth.wait_for_transaction_receipt(tx_hash)
+  print (f'[>] Hash of swap: {tx_hash}\n[>] {receipt}')
+  
+# --- END MAIN ---
+
+def sign_tx(tx, key):
+  return w3.eth.account.sign_transaction(tx, private_key=key)
+
+def send_tx(signed_tx):
+  return w3.eth.send_raw_transaction(signed_tx.raw_transaction)
+if __name__ == '__main__': 
+  main()
+
+#---------------------------------------------------------------------------------------------------------------------------------------------------------#
+


### PR DESCRIPTION
- Adds an example of signing an off chain permit for Uniswaps Universal Router, to reduce the number of transactions needed when swapping.
- Uses the extended process of building up the domain specific hashes, as opposed to sign typed data abstractions.
- Will put up a shorter more abstract example at some point, but fundamentals are here.